### PR TITLE
Improve autocompleter behavior

### DIFF
--- a/changelog/670.feature.rst
+++ b/changelog/670.feature.rst
@@ -2,3 +2,6 @@
 - Add :meth:`Injection.autocomplete <ext.commands.Injection.autocomplete>` decorator
 - Add :func:`injection <ext.commands.injection>` as a decorator interface for :func:`inject <ext.commands.inject>`
 - Add ``autocompleters`` keyword-only argument to :class:`Injection <ext.commands.Injection>`, :func:`inject <ext.commands.inject>`, and :func:`register_injection <ext.commands.register_injection>`
+- Add :attr:`SubCommand.parent <ext.commands.SubCommand.parent>`
+- Add :attr:`SubCommandGroup.parent <ext.commands.SubCommandGroup.parent>`
+- Add :attr:`SubCommand.parent_command <ext.commands.SubCommand.parent_command>` property


### PR DESCRIPTION
## Summary

This PR improves the behavior of autocomplete internals. Previously it was impossible to create a single autocompleter for multiple commands in different cogs, because the library would substitute the wrong cog during most of the calls. Cog substitution in autocompleters now works in a better way.

This PR also adds `.parent` attributes to `SubCommand` and `SubCommandGroup`. `SubCommand` now also has a `parent_command` property.

### Note
Autocomplete function signatures are now forced to match a specific pattern: `2 or 3 empty positional args + any amount of optional args + any amount of keyword-only args`. Examples of valid signatures:
- `func(inter, string)`
- `func(cog, inter, string)`
- `func(inter, string, extra=None)`
- `func(inter, string, **extra)`
- `func(inter, string, *, extra)`
- `func(cog, inter, string, extra=None)`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
